### PR TITLE
Fix math rendering: drop dead polyfill, async MathJax, enable AMS tags

### DIFF
--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,13 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true,
+    tags: "ams"
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex"
+  }
+};

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,9 +53,11 @@ plugins:
         - tags
 
 extra_javascript:
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
-  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
-  - https://unpkg.com/mermaid/dist/mermaid.min.js
+  - javascripts/mathjax.js
+  - path: https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+    async: true
+  - path: https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js
+    defer: true
 
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
Three issues caused math to render visibly late and equation numbers to go missing on the live site:

1. polyfill.io is sinkholed (HTTP 000) — every page load blocked while the browser waited for that script to fail before MathJax could start downloading. Dropped: MathJax 3 doesn't need it for any browser shipped in the last 5 years.

2. MathJax and mermaid loaded synchronously, blocking the parser. Switched to the object form of extra_javascript so MathJax gets async: true and mermaid gets defer: true (and is pinned to v10).

3. No MathJax config meant \begin{equation} blocks were not numbered. Added docs/javascripts/mathjax.js with tags: 'ams' so equation / align environments auto-number, and scoped the scan to .arithmatex elements (matches pymdownx.arithmatex generic mode).