### PR TITLE
Restore missing Eq. 11 in CTC note so Eq. 19 reference resolves

### DIFF
--- a/docs/neural_networks/ctc/ctc.md
+++ b/docs/neural_networks/ctc/ctc.md
@@ -287,11 +287,13 @@ We divide by $y^t_{\mathbf{l}^\prime_s}$ because both paths in the product inclu
 Continuing,
 
 $$
-\begin{align*}
+\begin{equation}
+\begin{aligned}
 \sum_{\pi \in \mathcal{B}^{-1}(\mathbf{l}):\pi_t=\mathbf{l}^\prime_s} p(\pi \mid \mathbf{x}) &= \frac{p_1(p_6 + p_7 + p_8 + p_9) + \dots + p_5(p_6 + p_7 + p_8 + p_9)}{y^t_{\mathbf{l}^\prime_s}}\\
 &= \frac{\left(p_1 + p_2 + p_3 + p_4 + p_5\right)\left(p_6 + p_7 + p_8 + p_9\right)}{y^t_{\mathbf{l}^\prime_s}}\\
 \implies \sum_{\pi \in \mathcal{B}^{-1}(\mathbf{l}):\pi_t=\mathbf{l}^\prime_s} p(\pi \mid \mathbf{x}) &= \frac{\alpha_t(s)\beta_t(s)}{y^t_{\mathbf{l}^\prime_s}}
-\end{align*}
+\end{aligned}
+\end{equation}
 $$
 
 If we do this for all symbols at a timestep, we will get all possible paths, i.e.:


### PR DESCRIPTION
The α·β/y derivation block was converted from Notion as a bare \begin{align*} (unnumbered), dropping one equation number from the total. As a result the closing "Eq. 19 is the error signal" line pointed at nothing. Re-wrap that block in \begin{equation} with \begin{aligned} inside, restoring the original numbering 1..19.